### PR TITLE
add arm64-v8a build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ www-test/
 ## Android Studio and Intellij and Android in general
 android/libs/armeabi/
 android/libs/armeabi-v7a/
+android/libs/arm64-v8a/
 android/libs/x86/
 android/gen/
 .idea/

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,15 @@
 android {
     buildToolsVersion "20.0.0"
+    namespace "fluddokt.opsu.android"
     compileSdkVersion 20
+    defaultConfig {
+        applicationId "fluddokt.opsu.android"
+        minSdk 20
+        targetSdk 20
+        versionCode 2
+        versionName "0.16.1a"
+    }
+
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
@@ -9,36 +18,44 @@ android {
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']
+            jniLibs.srcDirs = ['libs']
         }
-
-        instrumentTest.setRoot('tests')
+        sourceSets.androidTest.setRoot('tests')
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 
-// needed to add JNI shared libraries to APK when compiling on CLI
-tasks.withType(com.android.build.gradle.tasks.PackageApplication) { pkgTask ->
-    pkgTask.jniFolders = new HashSet<File>()
-    pkgTask.jniFolders.add(new File(projectDir, 'libs'))
+tasks.whenTaskAdded { task ->
+    if (task.name.contains('package') || task.name == 'preBuild') {
+        task.dependsOn copyAndroidNatives
+    }
 }
 
 // called every time gradle gets executed, takes the native dependencies of
 // the natives configuration, and extracts them to the proper libs/ folders
 // so they get packed with the APK.
-task copyAndroidNatives() { 
-    file("libs/armeabi/").mkdirs();
-    file("libs/armeabi-v7a/").mkdirs();
-    file("libs/x86/").mkdirs();
+task copyAndroidNatives() {
+    doFirst {
+        file("libs/armeabi/").mkdirs();
+        file("libs/armeabi-v7a/").mkdirs()
+        file("libs/arm64-v8a/").mkdirs()
+        file("libs/x86/").mkdirs()
 
-    configurations.natives.files.each { jar ->
-        def outputDir = null
-        if(jar.name.endsWith("natives-armeabi-v7a.jar")) outputDir = file("libs/armeabi-v7a")
-        if(jar.name.endsWith("natives-armeabi.jar")) outputDir = file("libs/armeabi")
-        if(jar.name.endsWith("natives-x86.jar")) outputDir = file("libs/x86")
-        if(outputDir != null) {
-            copy {
-                from zipTree(jar)
-                into outputDir
-                include "*.so"
+        configurations.natives.files.each { jar ->
+            def outputDir = null
+            if (jar.name.endsWith("natives-armeabi-v7a.jar")) outputDir = file("libs/armeabi-v7a")
+            if (jar.name.endsWith("natives-armeabi.jar")) outputDir = file("libs/armeabi")
+            if (jar.name.endsWith("natives-arm64-v8a.jar"))   outputDir = file("libs/arm64-v8a")
+            if (jar.name.endsWith("natives-x86.jar"))         outputDir = file("libs/x86")
+            if (outputDir != null) {
+                copy {
+                    from zipTree(jar)
+                    into outputDir
+                    include "*.so"
+                }
             }
         }
     }
@@ -82,7 +99,7 @@ eclipse {
     }
 
     classpath {
-        plusConfigurations += [ project.configurations.compile ]        
+        plusConfigurations += [ project.configurations.implementation ]
         containers 'com.android.ide.eclipse.adt.ANDROID_FRAMEWORK', 'com.android.ide.eclipse.adt.LIBRARIES'       
     }
 
@@ -103,7 +120,7 @@ eclipse {
 idea {
     module {
         sourceDirs += file("src");
-        scopes = [ COMPILE: [plus:[project.configurations.compile]]]        
+        scopes = [ IMPLEMENTATION: [plus:[project.configurations.implementation]]]
 
         iml {
             withXml {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ android {
     defaultConfig {
         applicationId "fluddokt.opsu.android"
         minSdk 20
-        targetSdk 20
+        targetSdk 24
         versionCode 2
         versionName "0.16.1a"
     }

--- a/android/src/fluddokt/opsu/android/AndroidLauncher.java
+++ b/android/src/fluddokt/opsu/android/AndroidLauncher.java
@@ -37,6 +37,14 @@ public class AndroidLauncher extends AndroidApplication {
 			public File getDownloadDir() {
 				return new File(new FileHandle(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)));
 			}
+
+			@Override
+			public String getStorageDir() {
+				java.io.File dir = AndroidLauncher.this.getExternalFilesDir(null);
+				if (dir == null)
+					dir = AndroidLauncher.this.getFilesDir();
+				return dir.getAbsolutePath();
+			}
 		};
 		initialize(new GameOpsu(), config);
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,13 @@
 buildscript {
     repositories {
+        google()
         mavenCentral()
         jcenter()
     }
     dependencies {
-        classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:1.0.0'
-        classpath 'org.robovm:robovm-gradle-plugin:1.0.0-beta-01'
+        classpath 'org.wisepersist:gwt-gradle-plugin:1.0.0'
+        classpath 'com.android.tools.build:gradle:8.5.0'
+        classpath 'org.robovm:robovm-gradle-plugin:1.6.0'
     }
 }
 
@@ -17,14 +18,15 @@ allprojects {
     version = '1.0'
     ext {
         appName = 'FKGdxOpsu'
-        gdxVersion = '1.5.2'
-        roboVMVersion = '1.0.0-beta-01'
+        gdxVersion = '1.9.2'
+        roboVMVersion = '1.6.0'
         box2DLightsVersion = '1.3'
         ashleyVersion = '1.3.1'
         aiVersion = '1.4.0'
     }
 
     repositories {
+        google()
         mavenCentral()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         maven { url "https://oss.sonatype.org/content/repositories/releases/" }
@@ -41,37 +43,38 @@ project(":desktop") {
 
 
     dependencies {
-        compile project(":core")
-        compile "com.badlogicgames.gdx:gdx-backend-lwjgl:$gdxVersion"
-        compile "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
-        compile "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop"
-        compile fileTree(dir: 'libs', include: '*.jar')
-        compile 'org.xerial:sqlite-jdbc:3.15.1'
+        implementation project(":core")
+        implementation "com.badlogicgames.gdx:gdx-backend-lwjgl:$gdxVersion"
+        implementation "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
+        implementation "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop"
+        implementation fileTree(dir: 'libs', include: '*.jar')
+        implementation 'org.xerial:sqlite-jdbc:3.15.1'
     }
 }
 
 project(":android") {
-    apply plugin: "android"
+    apply plugin: "com.android.application"
 
     configurations { natives }
 
     dependencies {
-        compile project(":core")
-        compile "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
+        implementation project(":core")
+        implementation "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
         natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-armeabi"
         natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-armeabi-v7a"
+        natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-arm64-v8a"
         natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-x86"
-        compile "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
+        implementation "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
         natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-armeabi"
         natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-armeabi-v7a"
+        natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-arm64-v8a"
         natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-x86"
-        compile fileTree(dir: 'libs', include: '*.jar')
-        compile 'org.sqldroid:sqldroid:1.0.3'
-        compile 'org.jcraft:jorbis:0.0.17'
-        compile 'net.lingala.zip4j:zip4j:1.3.2'
-        compile 'org.json:json:20160810'
-        compile 'org.tukaani:xz:1.6'
-        
+        implementation fileTree(dir: 'libs', include: '*.jar')
+        implementation 'org.sqldroid:sqldroid:1.0.3'
+        implementation 'org.jcraft:jorbis:0.0.17'
+        implementation 'net.lingala.zip4j:zip4j:1.3.2'
+        implementation 'org.json:json:20160810'
+        implementation 'org.tukaani:xz:1.6'
     }
 }
 
@@ -82,10 +85,10 @@ project(":ios") {
     configurations { natives }
 
     dependencies {
-        compile project(":core")
-        compile "org.robovm:robovm-rt:${roboVMVersion}"
-        compile "org.robovm:robovm-cocoatouch:${roboVMVersion}"
-        compile "com.badlogicgames.gdx:gdx-backend-robovm:$gdxVersion"
+        implementation project(":core")
+        implementation "org.robovm:robovm-rt:${roboVMVersion}"
+        implementation "org.robovm:robovm-cocoatouch:${roboVMVersion}"
+        implementation "com.badlogicgames.gdx:gdx-backend-robovm:$gdxVersion"
         natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-ios"
         natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-ios"
     }
@@ -93,14 +96,14 @@ project(":ios") {
 
 project(":html") {
     apply plugin: "gwt"
-    apply plugin: "war"
+    //apply plugin: "war"
 
 
     dependencies {
-        compile project(":core")
-        compile "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion"
-        compile "com.badlogicgames.gdx:gdx:$gdxVersion:sources"
-        compile "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion:sources"
+        implementation project(":core")
+        implementation "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion"
+        implementation "com.badlogicgames.gdx:gdx:$gdxVersion:sources"
+        implementation "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion:sources"
     }
 }
 
@@ -109,15 +112,14 @@ project(":core") {
 
 
     dependencies {
-        compile project(":jlayer")
-        compile "com.badlogicgames.gdx:gdx:$gdxVersion"
-        compile "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
-        compile fileTree(dir: 'libs', include: '*.jar')
-        compile 'org.jcraft:jorbis:0.0.17'
-        compile 'net.lingala.zip4j:zip4j:1.3.2'
-        compile 'org.json:json:20160810'
-        compile 'org.tukaani:xz:1.6'
-    
+        implementation project(":jlayer")
+        implementation "com.badlogicgames.gdx:gdx:$gdxVersion"
+        implementation "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
+        implementation fileTree(dir: 'libs', include: '*.jar')
+        implementation 'org.jcraft:jorbis:0.0.17'
+        implementation 'net.lingala.zip4j:zip4j:1.3.2'
+        implementation 'org.json:json:20160810'
+        implementation 'org.tukaani:xz:1.6'
     }
 }
 

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.6
+sourceCompatibility = 1.7
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 project.ext.mainClassName = "com.mygdx.game.desktop.DesktopLauncher"
 project.ext.assetsDir = new File("../android/assets");
 
 task run(dependsOn: classes, type: JavaExec) {
-    main = project.mainClassName
+    mainClass = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = project.assetsDir
@@ -15,11 +15,10 @@ task run(dependsOn: classes, type: JavaExec) {
 }
 
 task dist(type: Jar) {
-    from files(sourceSets.main.output.classesDir)
-    from files(sourceSets.main.output.resourcesDir)
+    from sourceSets.main.output
     from {configurations.compile.collect {zipTree(it)}}
-    from files(project.assetsDir);
- 
+
+    from project.assetsDir;
     manifest {
         attributes 'Main-Class': project.mainClassName
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Mar 16 04:57:54 CST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-all.zip

--- a/ios/build.gradle
+++ b/ios/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: "java"
+
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 sourceCompatibility = '1.7'
@@ -9,54 +11,59 @@ ext {
 
 // Extracts native libs (*.a) from the native-ios.jar and places them
 // under build/libs/ios/.
-task copyNatives << {
-  file("build/libs/ios/").mkdirs();
-  configurations.natives.files.each { jar ->
-    def outputDir = null
-    if (jar.name.endsWith("natives-ios.jar")) outputDir = file("build/libs/ios")
-    if (outputDir != null) {
-      copy {
-        from zipTree(jar)
-        into outputDir
-        include "*.a"
-      }
+task copyNatives {
+    doLast {
+        file("build/libs/ios/").mkdirs()
+        configurations.natives.files.each { jar ->
+            def outputDir = null
+            if (jar.name.endsWith("natives-ios.jar")) outputDir = file("build/libs/ios")
+            if (outputDir != null) {
+                copy {
+                    from zipTree(jar)
+                    into outputDir
+                    include "*.a"
+                }
+            }
+        }
     }
-  }
 }
 
 // Updates a robovm.xml file.
-task updateRoboVMXML << {
-  def xml = file('robovm.xml')
+task updateRoboVMXML {
+    dependsOn copyNatives
+    doLast {
+        def xml = file('robovm.xml')
 
-  if (!xml.exists()) {
-    return
-  }
-  
-  // Find all native (*.a) libraries beneath libs
-  def libtree = fileTree(dir: 'build/libs', include: '**/*.a')
-  
-  def config = new groovy.util.XmlParser().parse(xml)
-  config.libs.each {libs ->
-      libs.children().clear()
-      libtree.each { File file ->
-          libs.appendNode('lib', 'build/libs/ios/' + file.getName())
-      }
-  }
-  
-  def writer = new FileWriter(xml)
-  def printer = new XmlNodePrinter(new PrintWriter(writer))
-  printer.setPreserveWhitespace true
-  printer.print(config)
+        if (!xml.exists()) {
+            return
+        }
+
+        // Find all native (*.a) libraries beneath libs
+        def libtree = fileTree(dir: 'build/libs', include: '**/*.a')
+
+        def config = new groovy.util.XmlParser().parse(xml)
+        config.libs.each { libs ->
+            libs.children().clear()
+            libtree.each { File file ->
+                libs.appendNode('lib', 'build/libs/ios/' + file.getName())
+            }
+        }
+
+        def writer = new FileWriter(xml)
+        def printer = new XmlNodePrinter(new PrintWriter(writer))
+        printer.setPreserveWhitespace true
+        printer.print(config)
+    }
 }
 
 updateRoboVMXML.dependsOn copyNatives
 build.dependsOn updateRoboVMXML
 tasks.eclipse.dependsOn updateRoboVMXML
 
-launchIPhoneSimulator.dependsOn build
-launchIPadSimulator.dependsOn build
-launchIOSDevice.dependsOn build
-createIPA.dependsOn build
+//launchIPhoneSimulator.dependsOn build
+//launchIPadSimulator.dependsOn build
+//launchIOSDevice.dependsOn build
+//createIPA.dependsOn build
 
 
 eclipse.project {


### PR DESCRIPTION
1. Update gdx to 1.9.2, the lowest version [providing arm64-v8a builds](https://repo1.maven.org/maven2/com/badlogicgames/gdx/gdx-platform/1.9.0/) and [does not crash](https://github.com/libgdx/libgdx/blob/91caf85c5701edb297495e38c356bc7ab9db1131/CHANGES#L676).
2. Switched de.richsource.gradle.plugins:gwt-gradle-plugin to its fork, see https://github.com/libgdx/libgdx-demo-pax-britannica/issues/15.
3. Updated gradle and AGP and updated robovm, see https://github.com/robovm/robovm-gradle-plugin/issues/46.